### PR TITLE
fix: resolve onboarding screen appearing after app refresh for authenticated users

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,7 +36,8 @@
         }
       ],
       "expo-font",
-      "expo-web-browser"
+      "expo-web-browser",
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,41 @@
+import { useAuthStore } from '@/context/authStore';
+import { useOnboarding } from '@/hooks/useOnboarding';
 import { Redirect } from 'expo-router';
+import React from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
 export default function Index() {
-  // Redirect to the welcome screen by default
+  const { isAuthenticated, isLoading: authLoading } = useAuthStore();
+  const { isOnboardingCompleted, isLoading: onboardingLoading } = useOnboarding();
+
+  // Show loading while checking auth and onboarding status
+  if (authLoading || onboardingLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#007BFF" />
+      </View>
+    );
+  }
+
+  // If user is authenticated, go to main app
+  if (isAuthenticated) {
+    return <Redirect href="/(tabs)" />;
+  }
+
+  // If onboarding is completed but user is not authenticated, go to auth
+  if (isOnboardingCompleted) {
+    return <Redirect href="/(auth)/login" />;
+  }
+
+  // If onboarding is not completed, start with welcome
   return <Redirect href="/(welcome)/welcome" />;
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+});

--- a/context/authStore.ts
+++ b/context/authStore.ts
@@ -30,25 +30,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   initializeAuth: async () => {
     try {
       set({ isLoading: true });
-      
-      // Get current user
-      const user = await getCurrentUser();
-      
-      if (user) {
-        set({ 
-          user, 
-          isAuthenticated: true, 
-          isLoading: false 
-        });
-      } else {
-        set({ 
-          user: null, 
-          isAuthenticated: false, 
-          isLoading: false 
-        });
-      }
 
-      // Clean up any existing subscription
+      // Clean up any existing subscription first
       const currentState = get();
       if (currentState._unsubscribe && typeof currentState._unsubscribe === 'function') {
         currentState._unsubscribe();
@@ -65,6 +48,24 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       // Store the unsubscribe function
       set({ _unsubscribe: unsubscribe });
+      
+      // Get current user - this will trigger the onAuthStateChange callback
+      const user = await getCurrentUser();
+      
+      // Set initial state if no callback was triggered yet
+      if (user) {
+        set({ 
+          user, 
+          isAuthenticated: true, 
+          isLoading: false 
+        });
+      } else {
+        set({ 
+          user: null, 
+          isAuthenticated: false, 
+          isLoading: false 
+        });
+      }
 
     } catch (error) {
       console.error('Auth initialization error:', error);

--- a/hooks/useDebugInfo.ts
+++ b/hooks/useDebugInfo.ts
@@ -1,0 +1,65 @@
+import { useAuthStore } from '@/context/authStore';
+import { useOnboarding } from '@/hooks/useOnboarding';
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Debug utility to help troubleshoot authentication and onboarding flow issues
+ */
+export const useDebugInfo = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuthStore();
+  const { isOnboardingCompleted, isLoading: onboardingLoading } = useOnboarding();
+
+  const getDebugInfo = async () => {
+    try {
+      const onboardingStatus = await SecureStore.getItemAsync('onboardingCompleted');
+      
+      const debugInfo = {
+        auth: {
+          isAuthenticated,
+          userId: user?.id || null,
+          userEmail: user?.email || null,
+          isLoading: authLoading,
+        },
+        onboarding: {
+          isCompleted: isOnboardingCompleted,
+          isLoading: onboardingLoading,
+          rawStorageValue: onboardingStatus,
+        },
+        navigation: {
+          shouldShowWelcome: !isOnboardingCompleted && !isAuthenticated,
+          shouldShowAuth: isOnboardingCompleted && !isAuthenticated,
+          shouldShowTabs: isAuthenticated,
+        },
+        timestamp: new Date().toISOString(),
+      };
+
+      console.log('🐛 DEBUG INFO:', JSON.stringify(debugInfo, null, 2));
+      return debugInfo;
+    } catch (error) {
+      console.error('Error getting debug info:', error);
+      return null;
+    }
+  };
+
+  const resetAllData = async () => {
+    try {
+      // Clear onboarding data
+      await SecureStore.deleteItemAsync('onboardingCompleted');
+      
+      // Sign out user
+      const { signOutUser } = useAuthStore.getState();
+      await signOutUser();
+      
+      console.log('🧹 All data cleared for debugging');
+      return true;
+    } catch (error) {
+      console.error('Error resetting data:', error);
+      return false;
+    }
+  };
+
+  return {
+    getDebugInfo,
+    resetAllData,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "@supabase/supabase-js": "^2.50.0",
+        "date-fns": "^4.1.0",
         "expo": "53.0.12",
         "expo-apple-authentication": "~7.2.4",
         "expo-auth-session": "~6.2.0",
@@ -25,6 +26,7 @@
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.5",
         "expo-router": "~5.1.0",
+        "expo-secure-store": "~14.2.3",
         "expo-splash-screen": "~0.30.9",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
@@ -5418,6 +5420,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -6689,6 +6701,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.2.3.tgz",
+      "integrity": "sha512-hYBbaAD70asKTFd/eZBKVu+9RTo9OSTMMLqXtzDF8ndUGjpc6tmRCoZtrMHlUo7qLtwL5jm+vpYVBWI8hxh/1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "@supabase/supabase-js": "^2.50.0",
+    "date-fns": "^4.1.0",
     "expo": "53.0.12",
+    "expo-apple-authentication": "~7.2.4",
+    "expo-auth-session": "~6.2.0",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",
     "expo-font": "~13.3.1",
@@ -42,9 +45,8 @@
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "expo-apple-authentication": "~7.2.4",
-    "expo-auth-session": "~6.2.0",
-    "zustand": "^4.5.0"
+    "zustand": "^4.5.0",
+    "expo-secure-store": "~14.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -227,9 +227,12 @@ export const getCurrentUser = async (): Promise<User | null> => {
  * @returns Unsubscribe function
  */
 export const onAuthStateChange = (callback: (user: User | null) => void) => {
-  return supabase.auth.onAuthStateChange((event, session) => {
+  const { data } = supabase.auth.onAuthStateChange((event, session) => {
     callback(session?.user ?? null);
   });
+  
+  // Return the unsubscribe function
+  return data.subscription.unsubscribe;
 };
 
 /**

--- a/utils/migrateOnboardingData.ts
+++ b/utils/migrateOnboardingData.ts
@@ -1,0 +1,35 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+
+const OLD_ONBOARDING_KEY = 'onboardingCompleted';
+const NEW_ONBOARDING_KEY = 'onboardingCompleted';
+
+/**
+ * Migrate onboarding data from AsyncStorage to SecureStore
+ * This ensures backward compatibility for existing users
+ */
+export const migrateOnboardingData = async (): Promise<void> => {
+  try {
+    // Check if data already exists in SecureStore
+    const secureStoreValue = await SecureStore.getItemAsync(NEW_ONBOARDING_KEY);
+    if (secureStoreValue !== null) {
+      // Data already migrated, nothing to do
+      return;
+    }
+
+    // Check for old data in AsyncStorage
+    const asyncStorageValue = await AsyncStorage.getItem(OLD_ONBOARDING_KEY);
+    if (asyncStorageValue !== null) {
+      // Migrate the data
+      await SecureStore.setItemAsync(NEW_ONBOARDING_KEY, asyncStorageValue);
+      
+      // Clean up old data
+      await AsyncStorage.removeItem(OLD_ONBOARDING_KEY);
+      
+      console.log('Successfully migrated onboarding data to SecureStore');
+    }
+  } catch (error) {
+    console.error('Error migrating onboarding data:', error);
+    // Migration failure is not critical, the app can still function
+  }
+};


### PR DESCRIPTION
Fix: resolve onboarding screen appearing after app refresh for authenticated users

- Update app routing logic to properly check auth and onboarding states
- Migrate onboarding data from AsyncStorage to expo-secure-store for security
- Fix auth state initialization timing to prevent navigation loops
- Add proper loading states and conditional redirects in welcome screen
- Improve auth state change listener to return correct unsubscribe function
- Add data migration utility for backward compatibility
- Add debug utility for troubleshooting auth/onboarding issues

Fixes issue where logged-in users would see onboarding screen on app refresh